### PR TITLE
chore: Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,9 +67,7 @@
     "coveralls": "^2.13.1",
     "lodash": "4.17.x",
     "mocha": "^3.4.1",
-    "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^10.3.2",
-    "request": "^2.83.0",
     "semistandard": "^12.0.0",
     "sinon": "^4.0.2",
     "standard-version": "^4.3.0"


### PR DESCRIPTION
`request` wasn't used in the code so I assume it's some legacy dependency
`mocha-lcov-reporter` looks like a coverage helper but it's possible to make the coverage without it so it's probaböy legacy, too.