### PR TITLE
Feature/plds 255 fix vulnerable dependencies in software components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # @huf/rabbot - Changelog
 
+## 2.5.2 [2020-02-04]
+### Changed
+* PLDS-255 : update huf/rabbot dependencies - replace the `monologue.js` dependency with `node-monologue` which is actively maintained and fixes several security issues introduced through the `lodash` sub-dependency.
+
 ## 2.5.1 [2019-10-28]
 ### Changed
 * PLSA-51 : update huf/rabbot dependencies - update the machina dependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@huf/rabbot",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1528,22 +1528,6 @@
         }
       }
     },
-    "monologue.js": {
-      "version": "0.3.5",
-      "resolved": "https://artifactory.hufsm.intern/api/npm/hsm-npm-stage/monologue.js/-/monologue.js-0.3.5.tgz",
-      "integrity": "sha1-IM5RQ9ZegqOh91rakUfFJIeRSWk=",
-      "requires": {
-        "lodash": "3.x",
-        "riveter": "0.2.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://artifactory.hufsm.intern/api/npm/hsm-npm-stage/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
-      }
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://artifactory.hufsm.intern/api/npm/hsm-npm-stage/ms/-/ms-2.0.0.tgz",
@@ -1582,6 +1566,23 @@
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
+      }
+    },
+    "node-monologue": {
+      "version": "0.4.0",
+      "resolved": "https://artifactory.hufsm.intern/api/npm/hsm-npm-stage/node-monologue/-/node-monologue-0.4.0.tgz",
+      "integrity": "sha1-EArwsIYGZ+XdbSIfAmrZQbAUdkk=",
+      "requires": {
+        "lodash": "^4.17.15",
+        "node-riveter": "0.3.0"
+      }
+    },
+    "node-riveter": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.hufsm.intern/api/npm/hsm-npm-stage/node-riveter/-/node-riveter-0.3.0.tgz",
+      "integrity": "sha1-pRmA3pyRafOsxZw5qnbBevRqdIA=",
+      "requires": {
+        "lodash": "^4.17.15"
       }
     },
     "normalize-package-data": {
@@ -1964,21 +1965,6 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
-      }
-    },
-    "riveter": {
-      "version": "0.2.0",
-      "resolved": "https://artifactory.hufsm.intern/api/npm/hsm-npm-stage/riveter/-/riveter-0.2.0.tgz",
-      "integrity": "sha1-H3yOhlxFURX95ZS+JLAHLr3IvuQ=",
-      "requires": {
-        "lodash": "^2.4.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://artifactory.hufsm.intern/api/npm/hsm-npm-stage/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-        }
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@huf/rabbot",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Abstractions to simplify working with the RabbitMQ",
   "main": "src/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "debug": "^4.1.1",
     "lodash": "^4.17.14",
     "machina": "4.0.2",
-    "monologue.js": "^0.3.5",
+    "node-monologue": "^0.4.0",
     "postal": "^2.0.5",
     "uuid": "^3.3.2"
   }

--- a/src/ackBatch.js
+++ b/src/ackBatch.js
@@ -2,7 +2,7 @@
 
 const _ = require( "lodash" );
 const postal = require( "postal" );
-const Monologue = require( "monologue.js" );
+const Monologue = require( "node-monologue" );
 const signal = postal.channel( "rabbit.ack" );
 const log = require( "./log.js" )( "rabbot.acknack" );
 

--- a/src/amqp/iomonad.js
+++ b/src/amqp/iomonad.js
@@ -1,7 +1,7 @@
 // This is probably not a true monad, but it seems close based on my current understanding.
 
 var _ = require( "lodash" );
-var Monologue = require( "monologue.js" );
+var Monologue = require( "node-monologue" );
 var machina = require( "machina" );
 var log = require( "../log.js" )( "rabbot.io" );
 var format = require( "util" ).format;

--- a/src/connectionFsm.js
+++ b/src/connectionFsm.js
@@ -2,7 +2,7 @@
 
 var _ = require( "lodash" );
 
-var Monologue = require( "monologue.js" );
+var Monologue = require( "node-monologue" );
 var machina = require( "machina" );
 var format = require( "util" ).format;
 var log = require( "./log.js" )( "rabbot.connection" );

--- a/src/exchangeFsm.js
+++ b/src/exchangeFsm.js
@@ -1,6 +1,6 @@
 var _ = require( "lodash" );
 var machina = require( "machina" );
-var Monologue = require( "monologue.js" );
+var Monologue = require( "node-monologue" );
 var publishLog = require( "./publishLog" );
 var exLog = require( "./log.js" )( "rabbot.exchange" );
 var format = require( "util" ).format;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require( "lodash" );
-const Monologue = require( "monologue.js" );
+const Monologue = require( "node-monologue" );
 const connectionFn = require( "./connectionFsm.js" );
 const topologyFn = require( "./topology.js" );
 const postal = require( "postal" );

--- a/src/queueFsm.js
+++ b/src/queueFsm.js
@@ -3,7 +3,7 @@
 var _ = require( "lodash" );
 var machina = require( "machina" );
 var format = require( "util" ).format;
-var Monologue = require( "monologue.js" );
+var Monologue = require( "node-monologue" );
 Monologue.mixInto( machina.Fsm );
 var log = require( "./log.js" )( "rabbot.queue" );
 

--- a/src/topology.js
+++ b/src/topology.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var uuid = require( "uuid" );
-var Monologue = require( "monologue.js" );
+var Monologue = require( "node-monologue" );
 var log = require( "./log" )( "rabbot.topology" );
 var info = require( "./info" );
 var Exchange, Queue;


### PR DESCRIPTION
Replace monologue.js with node-monologue

monologue.js is no longer maintained and node-monologue fixes several
security issues introduced by the lodash dependency

I have run the tests with success (2 pending but this was also the case when running tests on development)

If possible, please also review the changes between monologue.js and node-monologue (I am not nodejs-skilled enough): https://github.com/postaljs/monologue.js/compare/master...Foo-Foo-MQ:master